### PR TITLE
allow broader meta parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-struct"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Define structs which have fields which are assigned to individual bits, not bytes"
 repository = "https://github.com/parallel-systems/bit-struct"

--- a/src/types.rs
+++ b/src/types.rs
@@ -104,25 +104,25 @@ macro_rules! new_signed_types {
         }
 
         impl PartialOrd for $name {
-            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
                 self.value().partial_cmp(&other.value())
             }
         }
 
         impl Ord for $name {
-            fn cmp(&self, other: &Self) -> Ordering {
+            fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
                 self.value().cmp(&other.value())
             }
         }
 
         impl Debug for $name {
-            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.write_fmt(format_args!("{}", self.value()))
             }
         }
 
         impl Display for $name {
-            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.write_fmt(format_args!("{}", self.value()))
             }
         }
@@ -287,7 +287,7 @@ macro_rules! num_traits {
             }
         }
 
-        impl core::str::FromStr for $num {
+        impl ::core::str::FromStr for $num {
             type Err = <Self as Num>::FromStrRadixErr;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -395,13 +395,13 @@ macro_rules! new_unsigned_types {
         always_valid!($name);
 
         impl Debug for $name {
-            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.write_fmt(format_args!("{}", self.0))
             }
         }
 
         impl Display for $name {
-            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.write_fmt(format_args!("{}", self.0))
             }
         }
@@ -644,7 +644,7 @@ macro_rules! byte_from_impls {
             /// The size of byte array equal to this value
             const ARR_SIZE: usize = <$kind>::COUNT / 8;
             /// The size of byte array equal to the underlying storage for this value
-            const SUPER_BYTES: usize = core::mem::size_of::<$super_kind>();
+            const SUPER_BYTES: usize = ::core::mem::size_of::<$super_kind>();
             /// Convert from an array of bytes, in big-endian order
             pub fn from_be_bytes(bytes: [u8; Self::ARR_SIZE]) -> Self {
                 let mut res_bytes = [0_u8; Self::SUPER_BYTES];

--- a/tests/doc_tests.rs
+++ b/tests/doc_tests.rs
@@ -11,7 +11,6 @@ bit_struct::enums! {
 bit_struct::bit_struct! {
     /// We can write documentation for the struct here. Here BitStruct1
     /// derives default values from the above enums macro
-    #[derive(Default)]
     struct BitStruct1 (u16){
         /// a 1 bit element. This is stored in u16[15]
         a: bit_struct::u1,
@@ -33,9 +32,20 @@ bit_struct::bit_struct! {
     }
 }
 
+impl Default for BitStruct1 {
+    fn default() -> Self {
+        Self::of_defaults()
+    }
+}
+
 #[test]
 fn full_test() {
     use std::convert::TryFrom;
+
+    assert_eq!(Animal::default(), Animal::Cat);
+    assert_eq!(BitStruct1::of_defaults().animal().get(), Animal::Cat);
+    assert_eq!(BitStruct1::default().animal().get(), Animal::Cat);
+
     let mut bit_struct: BitStruct1 = BitStruct1::default();
 
     assert_eq!(bit_struct.a().start(), 15);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,7 +17,6 @@ enums!(
 
 bit_struct!(
     /// `Abc` struct
-    #[derive(Default)]
     struct Abc(u16){
         mode: ModeA,
         _padding: u4,
@@ -39,6 +38,12 @@ bit_struct!(
         flag_b: bool,
     }
 );
+
+impl Default for Abc {
+    fn default() -> Self {
+        Self::of_defaults()
+    }
+}
 
 #[test]
 fn test_create() {


### PR DESCRIPTION
# Background

not all meta parameters (i.e., `#[allow(clippy::...)]` additions to structs/enums were accepted

# Description

- allow all meta parameters (i.e., `#[allow(clippy::...)]` additions to structs/enums were accepted
- remove special `#derive[(Default)]` specialization due to macro parsing conflicts with the new addition
  - still very easy to implement `Default` with use of `of_defaults()`
- bump version to `0.3.0` as ^ is a breaking change

# Verification

- [x] All tests pass
