### PR TITLE
Move serde to optional feature and remove mandatory downstream dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,17 @@ keywords = ["bit", "struct", "macros"]
 categories = ["no-std"]
 rust-version = "1.62.1"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 trybuild = "1.0"
 matches = "0.1.9"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"
+serde_json = "1.0"
+postcard = {version = "1.0.4", features = ["alloc"] }
+
+[features]
+default = ["serde"]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@
 //! types
 
 use super::*;
+#[cfg(feature = "serde")]
 use serde::{Deserializer, Serializer};
 
 /// Assert that the given type is valid for any representation thereof
@@ -84,6 +85,7 @@ macro_rules! new_signed_types {
 
         always_valid!($name);
 
+        #[cfg(feature = "serde")]
         impl serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -93,6 +95,7 @@ macro_rules! new_signed_types {
             }
         }
 
+        #[cfg(feature = "serde")]
         impl <'de> serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
@@ -406,6 +409,7 @@ macro_rules! new_unsigned_types {
             }
         }
 
+        #[cfg(feature = "serde")]
         impl serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -415,6 +419,7 @@ macro_rules! new_unsigned_types {
             }
         }
 
+        #[cfg(feature = "serde")]
         impl <'de> serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "serde")]
+
+use quickcheck::{Arbitrary, Gen};
+
+bit_struct::enums! {
+    pub Color { Orange, Red, Blue, Yellow, Green }
+}
+
+bit_struct::bit_struct! {
+    struct BitStruct(u32) {
+        a_color: Color,
+        b: bit_struct::u3,
+    }
+}
+
+impl Arbitrary for Color {
+    fn arbitrary(g: &mut Gen) -> Self {
+        *g.choose(&[
+            Self::Orange,
+            Self::Red,
+            Self::Blue,
+            Self::Yellow,
+            Self::Green,
+        ])
+        .unwrap()
+    }
+}
+
+impl Arbitrary for BitStruct {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let b = *g
+            .choose(&[
+                bit_struct::u3!(0),
+                bit_struct::u3!(1),
+                bit_struct::u3!(2),
+                bit_struct::u3!(3),
+                bit_struct::u3!(4),
+                bit_struct::u3!(5),
+                bit_struct::u3!(6),
+                bit_struct::u3!(7),
+            ])
+            .unwrap();
+        Self::new(Color::arbitrary(g), b)
+    }
+}
+
+#[quickcheck_macros::quickcheck]
+fn test_round_trip_serialize_json_enum(color: Color) -> bool {
+    use serde_json::{from_value, to_value};
+    let round_trip: Color =
+        from_value(to_value(color).expect("Failed to serialize")).expect("Failed to deserialize");
+    round_trip == color
+}
+
+#[quickcheck_macros::quickcheck]
+fn test_round_trip_serialize_postcard_enum(color: Color) -> bool {
+    use postcard::{from_bytes, to_allocvec};
+    let round_trip: Color = from_bytes(&to_allocvec(&color).expect("Failed to serialize"))
+        .expect("Failed to deserialize");
+    round_trip == color
+}
+
+#[quickcheck_macros::quickcheck]
+fn test_round_trip_serialize_json_struct(bits: BitStruct) -> bool {
+    use serde_json::{from_value, to_value};
+    let round_trip: BitStruct =
+        from_value(to_value(bits).expect("Failed to serialize")).expect("Failed to deserialize");
+    round_trip == bits
+}
+
+#[quickcheck_macros::quickcheck]
+fn test_round_trip_serialize_postcard_struct(bits: BitStruct) -> bool {
+    use postcard::{from_bytes, to_allocvec};
+    let round_trip: BitStruct = from_bytes(&to_allocvec(&bits).expect("Failed to serialize"))
+        .expect("Failed to deserialize");
+    round_trip == bits
+}


### PR DESCRIPTION
# Background

See issue #13

# Description

Makes `serde` an optional dependency and enables it to work in crates which don't have `serde` listed as an explicit dependency in their `Cargo.toml`.

I defaulted the feature to be present to minimize disruptions with existing uses of this crate that may rely on the `serde` implementations. However, it is still backwards-incompatible if anyone was relying on `serde` and already disabled the default features (idk why they would when there aren't any features).

Closes #13

# Verification

All tests pass, with or without the `serde` feature.

Also, I made a new crate locally which depends on this crate with the `serde` feature, and doesn't import `serde` (the case which would fail previously), and observed that it builds fine with both a `bit_struct!` and an `enums!` invocation.
